### PR TITLE
Add synonyms for ADO-style connection strings

### DIFF
--- a/.pipelines/README.md
+++ b/.pipelines/README.md
@@ -1,0 +1,7 @@
+# Azure pipelines for go-mssqldb
+
+## Purpose
+
+Created by @shueybubbles, a member of the SQL Server team at Microsoft. I built these pipelines to run tests against specific configurations of SQL Server and Azure SQL Database in our internal Azure Devops subscriptions.
+
+Each YML will be sufficiently parameterized to be runnable in other environments.

--- a/.pipelines/TestSql2017.yml
+++ b/.pipelines/TestSql2017.yml
@@ -1,6 +1,8 @@
 pool:
    vmImage: 'ubuntu-latest'
 
+trigger: none
+
 steps: 
 - task: GoTool@0
   inputs:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The recommended connection string uses a URL format:
 `sqlserver://username:password@host/instance?param1=value&param2=value`
 Other supported formats are listed below.
 
-### Common parameters:
+### Common parameters
 
 * `user id` - enter the SQL Server Authentication user id or the Windows Authentication user id in the DOMAIN\User format. On Windows, if user id is empty or missing Single-Sign-On is used. The user domain sensitive to the case which is defined in the connection string.
 * `password`
@@ -29,24 +29,24 @@ Other supported formats are listed below.
   * `true` - Data sent between client and server is encrypted.
 * `app name` - The application name (default is go-mssqldb)
 
-### Connection parameters for ODBC and ADO style connection strings:
+### Connection parameters for ODBC and ADO style connection strings
 
 * `server` - host or host\instance (default localhost)
 * `port` - used only when there is no instance in server (default 1433)
 
-### Less common parameters:
+### Less common parameters
 
 * `keepAlive` - in seconds; 0 to disable (default is 30)
-* `failoverpartner` - host or host\instance (default is no partner). 
+* `failoverpartner` - host or host\instance (default is no partner).
 * `failoverport` - used only when there is no instance in failoverpartner (default 1433)
 * `packet size` - in bytes; 512 to 32767 (default is 4096)
   * Encrypted connections have a maximum packet size of 16383 bytes
-  * Further information on usage: https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-the-network-packet-size-server-configuration-option
+  * Further information on usage: <https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-the-network-packet-size-server-configuration-option>
 * `log` - logging flags (default 0/no logging, 63 for full logging)
-  *  1 log errors
-  *  2 log messages
-  *  4 log rows affected
-  *  8 trace sql statements
+  * 1 log errors
+  * 2 log messages
+  * 4 log rows affected
+  * 8 trace sql statements
   * 16 log statement parameters
   * 32 log transaction begin/end
 * `TrustServerCertificate`
@@ -56,72 +56,80 @@ Other supported formats are listed below.
 * `hostNameInCertificate` - Specifies the Common Name (CN) in the server certificate. Default value is the server host.
 * `ServerSPN` - The kerberos SPN (Service Principal Name) for the server. Default is MSSQLSvc/host:port.
 * `Workstation ID` - The workstation name (default is the host name)
-* `ApplicationIntent` - Can be given the value `ReadOnly` to initiate a read-only connection to an Availability Group listener. The `database` must be specified when connecting with `Application Intent` set to `ReadOnly`. 
+* `ApplicationIntent` - Can be given the value `ReadOnly` to initiate a read-only connection to an Availability Group listener. The `database` must be specified when connecting with `Application Intent` set to `ReadOnly`.
 
-### The connection string can be specified in one of three formats:
-
+### The connection string can be specified in one of three formats
 
 1. URL: with `sqlserver` scheme. username and password appears before the host. Any instance appears as
     the first segment in the path. All other options are query parameters. Examples:
 
-  * `sqlserver://username:password@host/instance?param1=value&param2=value`
-  * `sqlserver://username:password@host:port?param1=value&param2=value`
-  * `sqlserver://sa@localhost/SQLExpress?database=master&connection+timeout=30` // `SQLExpress instance.
-  * `sqlserver://sa:mypass@localhost?database=master&connection+timeout=30`     // username=sa, password=mypass.
-  * `sqlserver://sa:mypass@localhost:1234?database=master&connection+timeout=30` // port 1234 on localhost.
-  * `sqlserver://sa:my%7Bpass@somehost?connection+timeout=30` // password is "my{pass"
+    * `sqlserver://username:password@host/instance?param1=value&param2=value`
+    * `sqlserver://username:password@host:port?param1=value&param2=value`
+    * `sqlserver://sa@localhost/SQLExpress?database=master&connection+timeout=30` // `SQLExpress instance.
+    * `sqlserver://sa:mypass@localhost?database=master&connection+timeout=30`     // username=sa, password=mypass.
+    * `sqlserver://sa:mypass@localhost:1234?database=master&connection+timeout=30` // port 1234 on localhost.
+    * `sqlserver://sa:my%7Bpass@somehost?connection+timeout=30` // password is "my{pass"
+      A string of this format can be constructed using the `URL` type in the `net/url` package.
 
-  A string of this format can be constructed using the `URL` type in the `net/url` package.
+    ```go
 
-```go
-  query := url.Values{}
-  query.Add("app name", "MyAppName")
+      query := url.Values{}
+      query.Add("app name", "MyAppName")
+    
+      u := &url.URL{
+          Scheme:   "sqlserver",
+          User:     url.UserPassword(username, password),
+          Host:     fmt.Sprintf("%s:%d", hostname, port),
+          // Path:  instance, // if connecting to an instance instead of a port
+          RawQuery: query.Encode(),
+      }
+      db, err := sql.Open("sqlserver", u.String())
 
-  u := &url.URL{
-      Scheme:   "sqlserver",
-      User:     url.UserPassword(username, password),
-      Host:     fmt.Sprintf("%s:%d", hostname, port),
-      // Path:  instance, // if connecting to an instance instead of a port
-      RawQuery: query.Encode(),
-  }
-  db, err := sql.Open("sqlserver", u.String())
-```
+    ```
 
 2. ADO: `key=value` pairs separated by `;`. Values may not contain `;`, leading and trailing whitespace is ignored.
      Examples:
-	
-  * `server=localhost\\SQLExpress;user id=sa;database=master;app name=MyAppName`
-  * `server=localhost;user id=sa;database=master;app name=MyAppName`
+
+    * `server=localhost\\SQLExpress;user id=sa;database=master;app name=MyAppName`
+    * `server=localhost;user id=sa;database=master;app name=MyAppName`
+
+    ADO strings support synonyms for database, app name, user id, and server
+    * server <= addr, address, network address, data source
+    * user id <= user, uid
+    * database <= initial catalog
+    * app name <= application name
 
 3. ODBC: Prefix with `odbc`, `key=value` pairs separated by `;`. Allow `;` by wrapping
     values in `{}`. Examples:
-	
-  * `odbc:server=localhost\\SQLExpress;user id=sa;database=master;app name=MyAppName`
-  * `odbc:server=localhost;user id=sa;database=master;app name=MyAppName`
-  * `odbc:server=localhost;user id=sa;password={foo;bar}` // Value marked with `{}`, password is "foo;bar"
-  * `odbc:server=localhost;user id=sa;password={foo{bar}` // Value marked with `{}`, password is "foo{bar"
-  * `odbc:server=localhost;user id=sa;password={foobar }` // Value marked with `{}`, password is "foobar "
-  * `odbc:server=localhost;user id=sa;password=foo{bar`   // Literal `{`, password is "foo{bar"
-  * `odbc:server=localhost;user id=sa;password=foo}bar`   // Literal `}`, password is "foo}bar"
-  * `odbc:server=localhost;user id=sa;password={foo{bar}` // Literal `{`, password is "foo{bar"
-  * `odbc:server=localhost;user id=sa;password={foo}}bar}` // Escaped `} with `}}`, password is "foo}bar"
+
+    * `odbc:server=localhost\\SQLExpress;user id=sa;database=master;app name=MyAppName`
+    * `odbc:server=localhost;user id=sa;database=master;app name=MyAppName`
+    * `odbc:server=localhost;user id=sa;password={foo;bar}` // Value marked with `{}`, password is "foo;bar"
+    * `odbc:server=localhost;user id=sa;password={foo{bar}` // Value marked with `{}`, password is "foo{bar"
+    * `odbc:server=localhost;user id=sa;password={foobar }` // Value marked with `{}`, password is "foobar "
+    * `odbc:server=localhost;user id=sa;password=foo{bar`   // Literal `{`, password is "foo{bar"
+    * `odbc:server=localhost;user id=sa;password=foo}bar`   // Literal `}`, password is "foo}bar"
+    * `odbc:server=localhost;user id=sa;password={foo{bar}` // Literal `{`, password is "foo{bar"
+    * `odbc:server=localhost;user id=sa;password={foo}}bar}` // Escaped `} with`}}`, password is "foo}bar"
 
 ### Azure Active Directory authentication - preview
 
 The configuration of functionality might change in the future.
 
-Azure Active Directory (AAD) access tokens are relatively short lived and need to be 
+Azure Active Directory (AAD) access tokens are relatively short lived and need to be
 valid when a new connection is made. Authentication is supported using a callback func that
 provides a fresh and valid token using a connector:
+
 ``` golang
 conn, err := mssql.NewAccessTokenConnector(
   "Server=test.database.windows.net;Database=testdb",
   tokenProvider)
 if err != nil {
-	// handle errors in DSN
+ // handle errors in DSN
 }
 db := sql.OpenDB(conn)
 ```
+
 Where `tokenProvider` is a function that returns a fresh access token or an error. None of these statements
 actually trigger the retrieval of a token, this happens when the first statment is issued and a connection
 is created.
@@ -129,31 +137,33 @@ is created.
 ## Executing Stored Procedures
 
 To run a stored procedure, set the query text to the procedure name:
+
 ```go
 var account = "abc"
 _, err := db.ExecContext(ctx, "sp_RunMe",
-	sql.Named("ID", 123),
-	sql.Named("Account", sql.Out{Dest: &account}),
+ sql.Named("ID", 123),
+ sql.Named("Account", sql.Out{Dest: &account}),
 )
 ```
 
 ## Reading Output Parameters from a Stored Procedure with Resultset
 
 To read output parameters from a stored procedure with resultset, make sure you read all the rows before reading the output parameters:
+
 ```go
 sqltextcreate := `
 CREATE PROCEDURE spwithoutputandrows
-	@bitparam BIT OUTPUT
+ @bitparam BIT OUTPUT
 AS BEGIN
-	SET @bitparam = 1
-	SELECT 'Row 1'
+ SET @bitparam = 1
+ SELECT 'Row 1'
 END
 `
 var bitout int64
 rows, err := db.QueryContext(ctx, "spwithoutputandrows", sql.Named("bitparam", sql.Out{Dest: &bitout}))
 var strrow string
 for rows.Next() {
-	err = rows.Scan(&strrow)
+ err = rows.Scan(&strrow)
 }
 fmt.Printf("bitparam is %d", bitout)
 ```
@@ -183,8 +193,8 @@ conn, err := pool.Conn(ctx)
 // Set us up so that temp table is always cleaned up, since conn.Close()
 // merely returns conn to pool, rather than actually closing the connection.
 defer func() {
-	_, _ = conn.ExecContext(ctx, "drop table #mytemp")  // always clean up
-	conn.Close() // merely returns conn to pool
+ _, _ = conn.ExecContext(ctx, "drop table #mytemp")  // always clean up
+ conn.Close() // merely returns conn to pool
 }()
 
 
@@ -201,7 +211,8 @@ _, err := conn.ExecContext(ctx, "insert into #mytemp (x) values (@p1)", 1)
 
 To get the procedure return status, pass into the parameters a
 `*mssql.ReturnStatus`. For example:
-```
+
+```go
 var rs mssql.ReturnStatus
 _, err := db.ExecContext(ctx, "theproc", &rs)
 log.Printf("status=%d", rs)
@@ -209,11 +220,11 @@ log.Printf("status=%d", rs)
 
 or
 
-```
+```go
 var rs mssql.ReturnStatus
 _, err := db.QueryContext(ctx, "theproc", &rs)
 for rows.Next() {
-	err = rows.Scan(&val)
+ err = rows.Scan(&val)
 }
 log.Printf("status=%d", rs)
 ```
@@ -235,30 +246,30 @@ To pass specific types to the query parameters, say `varchar` or `date` types,
 you must convert the types to the type before passing in. The following types
 are supported:
 
- * string -> nvarchar
- * mssql.VarChar -> varchar
- * time.Time -> datetimeoffset or datetime (TDS version dependent)
- * mssql.DateTime1 -> datetime
- * mssql.DateTimeOffset -> datetimeoffset
- * "github.com/golang-sql/civil".Date -> date
- * "github.com/golang-sql/civil".DateTime -> datetime2
- * "github.com/golang-sql/civil".Time -> time
- * mssql.TVP -> Table Value Parameter (TDS version dependent)
+* string -> nvarchar
+* mssql.VarChar -> varchar
+* time.Time -> datetimeoffset or datetime (TDS version dependent)
+* mssql.DateTime1 -> datetime
+* mssql.DateTimeOffset -> datetimeoffset
+* "github.com/golang-sql/civil".Date -> date
+* "github.com/golang-sql/civil".DateTime -> datetime2
+* "github.com/golang-sql/civil".Time -> time
+* mssql.TVP -> Table Value Parameter (TDS version dependent)
 
 ## Important Notes
 
- * [LastInsertId](https://golang.org/pkg/database/sql/#Result.LastInsertId) should
+* [LastInsertId](https://golang.org/pkg/database/sql/#Result.LastInsertId) should
     not be used with this driver (or SQL Server) due to how the TDS protocol
-	works. Please use the [OUTPUT Clause](https://docs.microsoft.com/en-us/sql/t-sql/queries/output-clause-transact-sql)
-	or add a `select ID = convert(bigint, SCOPE_IDENTITY());` to the end of your
-	query (ref [SCOPE_IDENTITY](https://docs.microsoft.com/en-us/sql/t-sql/functions/scope-identity-transact-sql)).
-	This will ensure you are getting the correct ID and will prevent a network round trip.
- * [NewConnector](https://godoc.org/github.com/denisenkom/go-mssqldb#NewConnector)
+ works. Please use the [OUTPUT Clause](https://docs.microsoft.com/en-us/sql/t-sql/queries/output-clause-transact-sql)
+ or add a `select ID = convert(bigint, SCOPE_IDENTITY());` to the end of your
+ query (ref [SCOPE_IDENTITY](https://docs.microsoft.com/en-us/sql/t-sql/functions/scope-identity-transact-sql)).
+ This will ensure you are getting the correct ID and will prevent a network round trip.
+* [NewConnector](https://godoc.org/github.com/denisenkom/go-mssqldb#NewConnector)
     may be used with [OpenDB](https://golang.org/pkg/database/sql/#OpenDB).
- * [Connector.SessionInitSQL](https://godoc.org/github.com/denisenkom/go-mssqldb#Connector.SessionInitSQL)
-	may be set to set any driver specific session settings after the session
-	has been reset. If empty the session will still be reset but use the database
-	defaults in Go1.10+.
+* [Connector.SessionInitSQL](https://godoc.org/github.com/denisenkom/go-mssqldb#Connector.SessionInitSQL)
+ may be set to set any driver specific session settings after the session
+ has been reset. If empty the session will still be reset but use the database
+ defaults in Go1.10+.
 
 ## Features
 
@@ -280,7 +291,9 @@ Environment variables are used to pass login information.
 
 Example:
 
+```bash
     env SQLSERVER_DSN=sqlserver://user:pass@hostname/instance?database=test1 go test
+```
 
 ## Deprecated
 
@@ -296,7 +309,7 @@ will be loosly parsed and an attempt to extract identifiers using one of
 * :nnn
 * $nnn
 
-will be used. This is not recommended with SQL Server. 
+will be used. This is not recommended with SQL Server.
 There is at least one existing `won't fix` issue with the query parsing.
 
 Use the native "@Name" parameters instead with the "sqlserver" driver name.
@@ -306,4 +319,4 @@ Use the native "@Name" parameters instead with the "sqlserver" driver name.
 * SQL Server 2008 and 2008 R2 engine cannot handle login records when SSL encryption is not disabled.
 To fix SQL Server 2008 R2 issue, install SQL Server 2008 R2 Service Pack 2.
 To fix SQL Server 2008 issue, install Microsoft SQL Server 2008 Service Pack 3 and Cumulative update package 3 for SQL Server 2008 SP3.
-More information: http://support.microsoft.com/kb/2653857
+More information: <http://support.microsoft.com/kb/2653857>

--- a/README.md
+++ b/README.md
@@ -73,17 +73,17 @@ Other supported formats are listed below.
 
     ```go
 
-      query := url.Values{}
-      query.Add("app name", "MyAppName")
+    query := url.Values{}
+    query.Add("app name", "MyAppName")
     
-      u := &url.URL{
-          Scheme:   "sqlserver",
-          User:     url.UserPassword(username, password),
-          Host:     fmt.Sprintf("%s:%d", hostname, port),
-          // Path:  instance, // if connecting to an instance instead of a port
-          RawQuery: query.Encode(),
-      }
-      db, err := sql.Open("sqlserver", u.String())
+    u := &url.URL{
+    	Scheme:   "sqlserver",
+    	User:     url.UserPassword(username, password),
+    	Host:     fmt.Sprintf("%s:%d", hostname, port),
+    	// Path:  instance, // if connecting to an instance instead of a port
+    	RawQuery: query.Encode(),
+    }
+    db, err := sql.Open("sqlserver", u.String())
 
     ```
 
@@ -120,14 +120,16 @@ Azure Active Directory (AAD) access tokens are relatively short lived and need t
 valid when a new connection is made. Authentication is supported using a callback func that
 provides a fresh and valid token using a connector:
 
-``` golang
+``` go
+
 conn, err := mssql.NewAccessTokenConnector(
-  "Server=test.database.windows.net;Database=testdb",
-  tokenProvider)
+	"Server=test.database.windows.net;Database=testdb",
+	tokenProvider)
 if err != nil {
- // handle errors in DSN
+	// handle errors in DSN
 }
 db := sql.OpenDB(conn)
+
 ```
 
 Where `tokenProvider` is a function that returns a fresh access token or an error. None of these statements
@@ -139,11 +141,13 @@ is created.
 To run a stored procedure, set the query text to the procedure name:
 
 ```go
+
 var account = "abc"
 _, err := db.ExecContext(ctx, "sp_RunMe",
- sql.Named("ID", 123),
- sql.Named("Account", sql.Out{Dest: &account}),
+	sql.Named("ID", 123),
+	sql.Named("Account", sql.Out{Dest: &account}),
 )
+
 ```
 
 ## Reading Output Parameters from a Stored Procedure with Resultset
@@ -151,21 +155,23 @@ _, err := db.ExecContext(ctx, "sp_RunMe",
 To read output parameters from a stored procedure with resultset, make sure you read all the rows before reading the output parameters:
 
 ```go
+
 sqltextcreate := `
 CREATE PROCEDURE spwithoutputandrows
- @bitparam BIT OUTPUT
+	@bitparam BIT OUTPUT
 AS BEGIN
- SET @bitparam = 1
- SELECT 'Row 1'
+	SET @bitparam = 1
+	SELECT 'Row 1'
 END
 `
 var bitout int64
 rows, err := db.QueryContext(ctx, "spwithoutputandrows", sql.Named("bitparam", sql.Out{Dest: &bitout}))
 var strrow string
 for rows.Next() {
- err = rows.Scan(&strrow)
+	err = rows.Scan(&strrow)
 }
 fmt.Printf("bitparam is %d", bitout)
+
 ```
 
 ## Caveat for local temporary tables
@@ -193,8 +199,8 @@ conn, err := pool.Conn(ctx)
 // Set us up so that temp table is always cleaned up, since conn.Close()
 // merely returns conn to pool, rather than actually closing the connection.
 defer func() {
- _, _ = conn.ExecContext(ctx, "drop table #mytemp")  // always clean up
- conn.Close() // merely returns conn to pool
+	_, _ = conn.ExecContext(ctx, "drop table #mytemp")  // always clean up
+	conn.Close() // merely returns conn to pool
 }()
 
 
@@ -213,9 +219,11 @@ To get the procedure return status, pass into the parameters a
 `*mssql.ReturnStatus`. For example:
 
 ```go
+
 var rs mssql.ReturnStatus
 _, err := db.ExecContext(ctx, "theproc", &rs)
 log.Printf("status=%d", rs)
+
 ```
 
 or
@@ -224,9 +232,10 @@ or
 var rs mssql.ReturnStatus
 _, err := db.QueryContext(ctx, "theproc", &rs)
 for rows.Next() {
- err = rows.Scan(&val)
+	err = rows.Scan(&val)
 }
 log.Printf("status=%d", rs)
+
 ```
 
 Limitation: ReturnStatus cannot be retrieved using `QueryRow`.
@@ -237,7 +246,9 @@ The `sqlserver` driver uses normal MS SQL Server syntax and expects parameters i
 the sql query to be in the form of either `@Name` or `@p1` to `@pN` (ordinal position).
 
 ```go
+
 db.QueryContext(ctx, `select * from t where ID = @ID and Name = @p2;`, sql.Named("ID", 6), "Bob")
+
 ```
 
 ### Parameter Types

--- a/conn_str.go
+++ b/conn_str.go
@@ -262,6 +262,17 @@ func (p connectParams) toUrl() *url.URL {
 	return &res
 }
 
+var adoSynonyms = map[string]string{
+	"application name": "app name",
+	"data source":      "server",
+	"address":          "server",
+	"network address":  "server",
+	"addr":             "server",
+	"user":             "user id",
+	"uid":              "user id",
+	"initial catalog":  "database",
+}
+
 func splitConnectionString(dsn string) (res map[string]string) {
 	res = map[string]string{}
 	parts := strings.Split(dsn, ";")
@@ -277,6 +288,10 @@ func splitConnectionString(dsn string) (res map[string]string) {
 		var value string = ""
 		if len(lst) > 1 {
 			value = strings.TrimSpace(lst[1])
+		}
+		synonym, hasSynonym := adoSynonyms[name]
+		if hasSynonym {
+			name = synonym
 		}
 		res[name] = value
 	}

--- a/conn_str.go
+++ b/conn_str.go
@@ -293,6 +293,16 @@ func splitConnectionString(dsn string) (res map[string]string) {
 		if hasSynonym {
 			name = synonym
 		}
+		// "server" in ADO can include a protocol and a port.
+		// We only support tcp protocol
+		if name == "server" {
+			value = strings.TrimPrefix(value, "tcp:")
+			serverParts := strings.Split(value, ",")
+			if len(serverParts) == 2 && len(serverParts[1]) > 0 {
+				value = serverParts[0]
+				res["port"] = serverParts[1]
+			}
+		}
 		res[name] = value
 	}
 	return res

--- a/conn_str_test.go
+++ b/conn_str_test.go
@@ -82,6 +82,16 @@ func TestValidConnectionString(t *testing.T) {
 		{"someparam", func(p connectParams) bool { return true }},
 		{";;=;", func(p connectParams) bool { return true }},
 
+		// https://github.com/denisenkom/go-mssqldb/issues/645 enable Application Name to mirror ADO
+		// Verify the various synonyms for server and database etc
+		{"application name=appname", func(p connectParams) bool { return p.appname == "appname" }},
+		{"data source=someserver;Initial Catalog=somedatabase;user=someuser", func(p connectParams) bool {
+			return p.host == "someserver" && p.database == "somedatabase" && p.user == "someuser"
+		}},
+		{"network address=someserver;uid=someuser", func(p connectParams) bool { return p.host == "someserver" && p.user == "someuser" }},
+		{"address=someserver", func(p connectParams) bool { return p.host == "someserver" }},
+		{"addr=someserver", func(p connectParams) bool { return p.host == "someserver" }},
+
 		// ODBC mode
 		{"odbc:server=somehost;user id=someuser;password=somepass", func(p connectParams) bool {
 			return p.host == "somehost" && p.user == "someuser" && p.password == "somepass"
@@ -186,10 +196,10 @@ func testConnParams(t testing.TB) connectParams {
 	}
 	if len(os.Getenv("HOST")) > 0 && len(os.Getenv("DATABASE")) > 0 {
 		return connectParams{
-			host: os.Getenv("HOST"),
+			host:     os.Getenv("HOST"),
 			instance: os.Getenv("INSTANCE"),
 			database: os.Getenv("DATABASE"),
-			user: os.Getenv("SQLUSER"),
+			user:     os.Getenv("SQLUSER"),
 			password: os.Getenv("SQLPASSWORD"),
 			logFlags: logFlags,
 		}

--- a/conn_str_test.go
+++ b/conn_str_test.go
@@ -21,6 +21,7 @@ func TestInvalidConnectionString(t *testing.T) {
 		"trustservercertificate=invalid",
 		"failoverport=invalid",
 		"applicationintent=ReadOnly",
+		"server=someserver,notanumber",
 
 		// ODBC mode
 		"odbc:password={",
@@ -92,6 +93,10 @@ func TestValidConnectionString(t *testing.T) {
 		{"address=someserver", func(p connectParams) bool { return p.host == "someserver" }},
 		{"addr=someserver", func(p connectParams) bool { return p.host == "someserver" }},
 
+		// ADO server names can include a tcp: prefix and a port suffix
+
+		{"server=tcp:someserver,1300", func(p connectParams) bool { return p.host == "someserver" && p.port == 1300 }},
+		{"data source=someserver,1300", func(p connectParams) bool { return p.host == "someserver" && p.port == 1300 }},
 		// ODBC mode
 		{"odbc:server=somehost;user id=someuser;password=somepass", func(p connectParams) bool {
 			return p.host == "somehost" && p.user == "someuser" && p.password == "somepass"


### PR DESCRIPTION
For https://github.com/denisenkom/go-mssqldb/issues/645

I've added mappings for some of the most commonly aliased items - server, user id, and database. I've also added `application name` as a synonym for the `app name` this driver currently supports. There may be other worthwhile synonyms. See <https://docs.microsoft.com/en-us/openspecs/sql_server_protocols/ms-sccstr/775b2bab-a604-4897-87e6-c36ee23dd3f1> for the full list.

I've also reformatted the readme a bit to satisfy the MD linter in vs code.

Queston about github etiquette - should I open this PR against denisenkom/go-mssqldb directly instead? I've not been active in OSS before. 

I am going to queue up a few changes in this fork first and open a PR to push them all over at once, but I can follow other preferred patterns as requested.